### PR TITLE
Refactor TruthDB installer build process to use GRUB and enhance ISO generation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
           sudo apt-get install -y shellcheck
 
       - name: Shellcheck
-        run: shellcheck ./build_and_run.sh ./run_container.sh
+        run: shellcheck ./build_and_run.sh ./build_in_container.sh ./build_iso.sh ./build_rootfs_payload.sh ./run_container.sh ./initramfs/init
 
   build:
     name: Build ISO
@@ -42,9 +42,17 @@ jobs:
             build-essential pkg-config \
             cpio zstd \
             busybox-static \
+            util-linux \
+            fdisk \
+            parted \
+            e2fsprogs \
+            efibootmgr \
             python3 \
-            systemd-ukify \
+            systemd \
             systemd-boot-efi \
+            grub-common \
+            grub-pc-bin \
+            grub-efi-amd64-bin \
             file \
             xorriso \
             dosfstools mtools \
@@ -128,77 +136,13 @@ jobs:
       
       - name: Build ISO
         run: |
-          # Set environment variables for the build script
           export KERNEL_SRC="${PWD}/kernel-bin/BOOTX64.EFI"
           export INSTALLER_BIN="${PWD}/installer-bin/truthdb-installer"
           export ISO_NAME="truthdb-installer.iso"
-          
-          # Verify files exist
+
           ls -lh "$KERNEL_SRC" "$INSTALLER_BIN"
-          
-          # Build the initramfs
-          rm -rf rootfs
-          mkdir -p rootfs/{bin,sbin,etc,proc,sys,dev,run,tmp}
-          
-          cp /bin/busybox rootfs/bin/busybox
-          chmod +x rootfs/bin/busybox
-          ln -sf /bin/busybox rootfs/sbin/init
-          ln -sf /bin/busybox rootfs/bin/sh
-          
-          cp "$INSTALLER_BIN" rootfs/bin/truthdb-installer
-          chmod +x rootfs/bin/truthdb-installer
-          
-          cat > rootfs/etc/inittab <<'EOF'
-          ::sysinit:/bin/busybox mount -t proc proc /proc
-          ::sysinit:/bin/busybox mount -t sysfs sysfs /sys
-          ::sysinit:/bin/busybox mount -t devtmpfs devtmpfs /dev
-          ::respawn:/bin/busybox sh -c '/bin/truthdb-installer </dev/console >/dev/console 2>&1'
-          ::restart:/bin/busybox reboot -f
-          EOF
-          
-          rm -f initramfs.cpio initramfs.cpio.zst
-          ( cd rootfs && find . -print0 | cpio --null -ov --format=newc ) > initramfs.cpio
-          zstd -19 -T0 initramfs.cpio -o initramfs.cpio.zst
-          
-          # Create cmdline
-          cat > cmdline.txt <<'EOF'
-          console=ttyS0,115200 earlycon=efi loglevel=7 console=tty0 rdinit=/sbin/init
-          EOF
-          
-          # Build UKI
-          cp "$KERNEL_SRC" ./vmlinuz
-          
-          ukify build \
-            --linux ./vmlinuz \
-            --initrd ./initramfs.cpio.zst \
-            --cmdline @./cmdline.txt \
-            --output ./TruthDBInstaller.efi
-          
-          file ./TruthDBInstaller.efi
-          
-          # Create EFI image
-          rm -f efi.img
-          dd if=/dev/zero of=efi.img bs=1M count=128
-          mkfs.vfat -F 32 efi.img
-          
-          mmd   -i efi.img ::/EFI
-          mmd   -i efi.img ::/EFI/BOOT
-          mcopy -i efi.img ./TruthDBInstaller.efi ::/EFI/BOOT/BOOTX64.EFI
-          
-          # Create ISO
-          rm -f "$ISO_NAME"
-          
-          xorriso -as mkisofs \
-            -R -J \
-            -o "$ISO_NAME" \
-            -eltorito-alt-boot \
-            -e efi.img \
-            -no-emul-boot \
-            -isohybrid-gpt-basdat \
-            -graft-points efi.img=efi.img
-          
-          echo "ISO ready: $ISO_NAME"
-          ls -lh "$ISO_NAME"
+          chmod +x ./build_iso.sh
+          ./build_iso.sh
       
       - name: Upload ISO artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,12 +74,17 @@ jobs:
             cpio zstd \
             busybox-static \
             util-linux \
+            fdisk \
+            parted \
+            e2fsprogs \
             efibootmgr \
             debootstrap debian-archive-keyring \
             python3 \
             systemd \
-            systemd-ukify \
             systemd-boot-efi \
+            grub-common \
+            grub-pc-bin \
+            grub-efi-amd64-bin \
             file \
             xorriso \
             dosfstools mtools \
@@ -110,98 +115,18 @@ jobs:
           echo "==> Disk usage (before debootstrap)"
           df -h
 
-          PAYLOAD_NAME="debian-minbase-amd64-bookworm.tar.zst"
-          ROOTFS_DIR="${PWD}/debian-rootfs"
-
-          sudo rm -rf "$ROOTFS_DIR" "$PAYLOAD_NAME"
-
-          # Minimal bootable Debian userspace (kernel/initramfs installed into /boot by package scripts).
-          # Keep this list intentionally short; the installer will do host-specific config later.
-          sudo debootstrap \
-            --arch=amd64 \
-            --variant=minbase \
-            --include=systemd-sysv,systemd-resolved,linux-image-amd64,initramfs-tools,ca-certificates,sudo,passwd,iproute2,dbus \
-            bookworm \
-            "$ROOTFS_DIR" \
-            http://deb.debian.org/debian
-
-          # Embed the matching TruthDB service artifacts into the payload.
-          echo "Resolving latest truthdb release"
-
-          RELEASE=$(curl -fsSL \
-            -H "Authorization: Bearer ${GITHUB_TOKEN}" \
-            -H "Accept: application/vnd.github+json" \
-            "https://api.github.com/repos/Truthdb/truthdb/releases/latest")
-
-          DEP_TAG=$(echo "$RELEASE" | jq -r '.tag_name')
-          echo "Using truthdb release: ${DEP_TAG}"
-
-          DOWNLOAD_URL=$(echo "$RELEASE" | jq -r '.assets // [] | .[] | select(.name | endswith("-x86_64-linux-gnu.tar.gz")) | .browser_download_url' | head -n 1)
-          CHECKSUM_URL=$(echo "$RELEASE" | jq -r '.assets // [] | .[] | select(.name | endswith("-x86_64-linux-gnu.sha256")) | .browser_download_url' | head -n 1)
-          if [ -z "$DOWNLOAD_URL" ] || [ "$DOWNLOAD_URL" = "null" ]; then
-            echo "ERROR: No truthdb binary archive found in release (expected *-x86_64-linux-gnu.tar.gz)"
-            exit 1
-          fi
-          if [ -z "$CHECKSUM_URL" ] || [ "$CHECKSUM_URL" = "null" ]; then
-            echo "ERROR: No truthdb checksum found in release (expected *-x86_64-linux-gnu.sha256)"
-            exit 1
-          fi
-
-          echo "Downloading truthdb from: $DOWNLOAD_URL"
-          rm -rf truthdb-dist
-          mkdir -p truthdb-dist
-          curl -fsSL -o truthdb-dist/truthdb.tar.gz "$DOWNLOAD_URL"
-          curl -fsSL -o truthdb-dist/truthdb.sha256 "$CHECKSUM_URL"
-          tar xzf truthdb-dist/truthdb.tar.gz -C truthdb-dist
-          test -x truthdb-dist/truthdb
-          test -f truthdb-dist/truthdb.service
-
-          expected_truthdb_sha=$(awk 'NR==1 {print $1}' truthdb-dist/truthdb.sha256)
-          actual_truthdb_sha=$(sha256sum truthdb-dist/truthdb | awk '{print $1}')
-          if [ -z "$expected_truthdb_sha" ] || [ "$expected_truthdb_sha" != "$actual_truthdb_sha" ]; then
-            echo "ERROR: truthdb checksum verification failed"
-            echo "Expected: ${expected_truthdb_sha:-<empty>}"
-            echo "Actual:   $actual_truthdb_sha"
-            exit 1
-          fi
-
-          # Install into the rootfs payload.
-          sudo install -d "$ROOTFS_DIR/usr/local/bin" "$ROOTFS_DIR/lib/systemd/system" "$ROOTFS_DIR/etc/systemd/system/multi-user.target.wants"
-          sudo install -m 0755 truthdb-dist/truthdb "$ROOTFS_DIR/usr/local/bin/truthdb"
-          sudo install -m 0644 truthdb-dist/truthdb.service "$ROOTFS_DIR/lib/systemd/system/truthdb.service"
-
-          # Enable at boot (multi-user target).
-          sudo ln -sf /lib/systemd/system/truthdb.service \
-            "$ROOTFS_DIR/etc/systemd/system/multi-user.target.wants/truthdb.service"
-
-          # Sanity checks: verify key tools and service artifacts exist in the payload.
-          test -x "$ROOTFS_DIR/usr/sbin/ip" || test -x "$ROOTFS_DIR/bin/ip" || test -x "$ROOTFS_DIR/sbin/ip"
-          test -x "$ROOTFS_DIR/usr/local/bin/truthdb"
-          test -f "$ROOTFS_DIR/lib/systemd/system/truthdb.service"
-          test -L "$ROOTFS_DIR/etc/systemd/system/multi-user.target.wants/truthdb.service"
-
-          # Shrink the payload: remove apt lists/caches and documentation.
-          sudo rm -rf "$ROOTFS_DIR/var/lib/apt/lists"/* || true
-          sudo rm -rf "$ROOTFS_DIR/var/cache/apt/archives"/*.deb || true
-          sudo rm -rf "$ROOTFS_DIR/usr/share/doc" || true
-          sudo rm -rf "$ROOTFS_DIR/usr/share/man" || true
-          sudo rm -rf "$ROOTFS_DIR/usr/share/info" || true
-          sudo rm -rf "$ROOTFS_DIR/usr/share/locale" || true
-
-          echo "==> Disk usage (after debootstrap + cleanup)"
-          df -h
-
-          sudo tar --numeric-owner -C "$ROOTFS_DIR" -cpf - . \
-            | zstd -19 -T0 -o "$PAYLOAD_NAME"
-
-          # Free workspace disk for subsequent ISO build steps.
-          sudo rm -rf "$ROOTFS_DIR"
+          chmod +x ./build_rootfs_payload.sh
+          export TRUTHDB_SOURCE=release
+          export TRUTHDB_REPO=Truthdb/truthdb
+          export ROOTFS_DIR="${PWD}/debian-rootfs"
+          export PAYLOAD_PATH="${PWD}/debian-minbase-amd64-bookworm.tar.zst"
+          ./build_rootfs_payload.sh
 
           echo "==> Disk usage (after packing payload)"
           df -h
 
-          ls -lh "$PAYLOAD_NAME"
-          echo "ROOTFS_PAYLOAD=${PWD}/${PAYLOAD_NAME}" >> "$GITHUB_ENV"
+          ls -lh "${PAYLOAD_PATH}"
+          echo "ROOTFS_PAYLOAD=${PAYLOAD_PATH}" >> "$GITHUB_ENV"
       
       - name: Download matching installer binary
         run: |
@@ -291,173 +216,17 @@ jobs:
       
       - name: Build ISO
         run: |
-          # Set environment variables for the build
           export KERNEL_SRC="${PWD}/kernel-bin/BOOTX64.EFI"
           export INSTALLER_BIN="${PWD}/installer-bin/truthdb-installer"
+          export ROOTFS_PAYLOAD="${ROOTFS_PAYLOAD}"
           export ISO_NAME="truthdb-installer.iso"
-          
-          # Verify files exist
-          ls -lh "$KERNEL_SRC" "$INSTALLER_BIN"
-          
-          # Build the initramfs
-          rm -rf rootfs
-          mkdir -p rootfs/{bin,sbin,etc,proc,sys,dev,run,tmp}
 
-          # Copy a dynamically linked binary and all of its shared library deps into rootfs.
-          copy_bin_with_libs() {
-            local src="$1"
-            if [[ ! -x "$src" ]]; then
-              echo "ERROR: required tool not found or not executable: $src" >&2
-              exit 1
-            fi
+          ls -lh "$KERNEL_SRC" "$INSTALLER_BIN" "$ROOTFS_PAYLOAD"
+          chmod +x ./build_iso.sh
+          ./build_iso.sh
 
-            mkdir -p "rootfs$(dirname "$src")"
-            cp -L "$src" "rootfs$src"
-
-            ldd "$src" \
-              | awk '{ for (i = 1; i <= NF; i++) if ($i ~ /^\//) print $i }' \
-              | while read -r dep; do
-                  mkdir -p "rootfs$(dirname "$dep")"
-                  cp -L "$dep" "rootfs$dep"
-                done
-          }
-          
-          cp /bin/busybox rootfs/bin/busybox
-          chmod +x rootfs/bin/busybox
-          ln -sf /bin/busybox rootfs/sbin/init
-          ln -sf /bin/busybox rootfs/bin/sh
-          
-          cp "$INSTALLER_BIN" rootfs/bin/truthdb-installer
-          chmod +x rootfs/bin/truthdb-installer
-
-          # Offline Debian payload embedded in initramfs.
-          mkdir -p rootfs/payload
-          cp "$ROOTFS_PAYLOAD" rootfs/payload/debian-minbase-amd64-bookworm.tar.zst
-
-          echo "==> Sizes before initramfs pack"
-          ls -lh "$ROOTFS_PAYLOAD" || true
-          du -sh rootfs || true
-
-          # Required external tools for destructive install steps.
-          # These must exist in initramfs because the installer execs them directly (no shell).
-          copy_bin_with_libs /usr/sbin/wipefs
-          copy_bin_with_libs /usr/sbin/sfdisk
-          copy_bin_with_libs /usr/sbin/partprobe
-          copy_bin_with_libs /usr/sbin/blkid
-          efibootmgr_path=$(command -v efibootmgr || true)
-          if [[ -n "$efibootmgr_path" ]]; then
-            copy_bin_with_libs "$efibootmgr_path"
-          else
-            echo "ERROR: efibootmgr not found in PATH" >&2
-            exit 1
-          fi
-          # Filesystem + mount + extraction tools used by the installer.
-          copy_bin_with_libs /usr/sbin/mkfs.vfat
-          copy_bin_with_libs /usr/sbin/mkfs.ext4
-          copy_bin_with_libs /usr/bin/mount
-          copy_bin_with_libs /usr/bin/umount
-          copy_bin_with_libs /usr/bin/tar
-          copy_bin_with_libs /usr/bin/zstd
-
-          # Needed for configuring the installed system (passwords/users) from initramfs.
-          chroot_path=$(command -v chroot || true)
-          if [[ -n "$chroot_path" ]]; then
-            copy_bin_with_libs "$chroot_path"
-          else
-            echo "ERROR: chroot not found in PATH" >&2
-            exit 1
-          fi
-
-          # Bootloader tooling (systemd-boot).
-          bootctl_path=$(command -v bootctl || true)
-          if [[ -n "$bootctl_path" ]]; then
-            copy_bin_with_libs "$bootctl_path"
-          else
-            echo "WARN: bootctl not found in PATH; installer will copy systemd-boot EFI directly"
-          fi
-          if [[ -d /usr/lib/systemd/boot/efi ]]; then
-            mkdir -p rootfs/usr/lib/systemd/boot
-            cp -a /usr/lib/systemd/boot/efi rootfs/usr/lib/systemd/boot/
-          else
-            echo "ERROR: /usr/lib/systemd/boot/efi not found (need systemd-boot EFI binaries)" >&2
-            exit 1
-          fi
-          
-          cat > rootfs/etc/inittab <<'EOF'
-          ::sysinit:/bin/busybox mount -t proc proc /proc
-          ::sysinit:/bin/busybox mount -t sysfs sysfs /sys
-          ::sysinit:/bin/busybox mount -t devtmpfs devtmpfs /dev
-          ::respawn:/bin/busybox sh -c '/bin/truthdb-installer </dev/console >/dev/console 2>&1'
-          ::restart:/bin/busybox reboot -f
-          EOF
-          
-          # Build initramfs without storing a giant intermediate initramfs.cpio on disk.
-          rm -f initramfs.cpio.zst
-          ( cd rootfs && find . -print0 | cpio --null -ov --format=newc ) \
-            | zstd -19 -T0 -o initramfs.cpio.zst
-
-          # Free workspace disk ASAP; the payload is now inside initramfs.
-          rm -rf rootfs
           rm -f "$ROOTFS_PAYLOAD" || true
-
-          echo "==> Sizes after initramfs pack"
-          ls -lh initramfs.cpio.zst
-          
-          # Create cmdline
-          cat > cmdline.txt <<'EOF'
-          console=ttyS0,115200 earlycon=efi loglevel=7 console=tty0 rdinit=/sbin/init
-          EOF
-          
-          # Build UKI
-          cp "$KERNEL_SRC" ./vmlinuz
-          
-          ukify build \
-            --linux ./vmlinuz \
-            --initrd ./initramfs.cpio.zst \
-            --cmdline @./cmdline.txt \
-            --output ./TruthDBInstaller.efi
-          
-          file ./TruthDBInstaller.efi
-
-          # We no longer need these large intermediates after the UKI is built.
-          rm -f initramfs.cpio.zst
-          rm -f vmlinuz cmdline.txt
           rm -rf installer-bin kernel-bin || true
-
-          echo "==> Disk usage before creating EFI image"
-          df -h
-          
-          # Create EFI image
-          rm -f efi.img
-
-          # Size the FAT image based on the UKI size (avoid wasting space on small runners).
-          uki_bytes=$(stat -c%s ./TruthDBInstaller.efi)
-          uki_mib=$(( (uki_bytes + 1024*1024 - 1) / (1024*1024) ))
-          efi_mib=$(( uki_mib + 32 ))
-          if (( efi_mib < 32 )); then efi_mib=32; fi
-          echo "Creating efi.img: ${efi_mib}MiB (UKI ~${uki_mib}MiB)"
-
-          dd if=/dev/zero of=efi.img bs=1M count="$efi_mib"
-          mkfs.vfat -F 32 efi.img
-          
-          mmd   -i efi.img ::/EFI
-          mmd   -i efi.img ::/EFI/BOOT
-          mcopy -i efi.img ./TruthDBInstaller.efi ::/EFI/BOOT/BOOTX64.EFI
-          
-          # Create ISO
-          rm -f "$ISO_NAME"
-          
-          xorriso -as mkisofs \
-            -R -J \
-            -o "$ISO_NAME" \
-            -eltorito-alt-boot \
-            -e efi.img \
-            -no-emul-boot \
-            -isohybrid-gpt-basdat \
-            -graft-points efi.img=efi.img
-          
-          echo "ISO ready: $ISO_NAME"
-          ls -lh "$ISO_NAME"
       
       - name: Generate checksum
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -24,11 +24,14 @@ target
 rootfs/
 initramfs.cpio
 initramfs.cpio.zst
+initrd.img
+iso-root/
 cmdline.txt
 vmlinuz
 TruthDBInstaller.efi
 efi.img
 *.iso
+*.iso.sha256
 OVMF_CODE.fd
 OVMF_VARS.fd
 

--- a/README.md
+++ b/README.md
@@ -4,12 +4,12 @@ Build tooling and CI for producing the TruthDB installer ISO.
 
 ## Overview
 
-The ISO boots via UEFI and contains a UKI (Unified Kernel Image) built with `ukify`. The UKI includes an initramfs that runs the `truthdb-installer` binary.
+The ISO boots through `GRUB` and loads a normal Linux kernel plus installer initramfs. The initramfs then launches the `truthdb-installer` binary on the active console by default, with a separate GRUB entry available for dedicated-VT testing.
 
 There are two relevant build paths:
 
-- **Local/dev script**: `build_and_run.sh` builds a minimal initramfs (BusyBox + installer) and can boot-test it in QEMU.
-- **Release workflow**: GitHub Actions builds an ISO that also embeds an offline Debian rootfs payload and copies required install tools into initramfs.
+- **Local/dev script**: `build_and_run.sh` builds the GRUB-based installer ISO locally and can boot-test it in QEMU.
+- **Release workflow**: GitHub Actions builds the same GRUB-based ISO, but also embeds an offline Debian rootfs payload and copies required install tools into initramfs.
 
 ## Local Development (Docker)
 
@@ -21,31 +21,74 @@ Then (inside the container) run:
 
 `./build_and_run.sh`
 
+If you want the whole local container build in one step instead of entering a shell first:
+
+`./build_in_container.sh`
+
+By default this runs in local development mode (`INPUT_MODE=dev`).
+
 This will:
 
-- Install dependencies (ukify, xorriso, qemu/ovmf, etc.)
-- Optionally build `truthdb-installer` from the sibling `installer/` repo (see `BUILD_INSTALLER`)
-- Download a kernel EFI binary from the latest `installer-kernel` release (or a specified tag)
-- Build a UKI and package it into an ISO
-- Optionally boot-test in QEMU (enabled by default)
+- Install dependencies (GRUB, xorriso, qemu/ovmf, etc.)
+- Build `truthdb-installer` from the sibling `installer/` repo by default
+- Build `truthdb` from the sibling `truthdb/` repo by default for the embedded Debian payload
+- Build and embed the Debian rootfs payload by default
+- Download the installer kernel from the latest `installer-kernel` release (or a specified tag)
+- Build a GRUB-based installer ISO
+- Skip the QEMU boot test by default so the wrapper can be used from macOS hosts without container GUI setup
 
 ### Useful Environment Variables (build_and_run.sh)
 
-- `KERNEL_SRC`: path to a kernel image/EFI payload. If unset, downloads `BOOTX64.EFI` from releases.
+- `INPUT_MODE`: `dev` or `release`. `dev` builds local workspace binaries by default; `release` uses published release artifacts by default.
+- `KERNEL_SRC`: path to a Linux kernel image. If unset, downloads the current `BOOTX64.EFI` kernel release asset and uses it as the installer kernel.
 - `KERNEL_TAG`: if set (e.g. `v1.2.3`), downloads that exact `installer-kernel` release asset.
+- `KERNEL_REPO`: GitHub repo to query for installer-kernel releases.
+- `INSTALLER_REPO`: GitHub repo to query for installer releases.
+- `TRUTHDB_REPO`: GitHub repo to query for truthdb releases.
 - `INSTALLER_BIN`: path to `truthdb-installer` (defaults to a sibling repo build output).
 - `BUILD_INSTALLER`: `1` to build the installer inside the container.
+- `BUILD_TRUTHDB`: `1` to build `truthdb` inside the container for payload embedding.
+- `BUILD_ROOTFS_PAYLOAD`: `1` to build and embed the Debian payload locally.
+- `ROOTFS_PAYLOAD`: path to a prebuilt Debian payload tarball to embed instead of building one.
+- `TRUTHDB_SOURCE`: `local`, `release`, or `auto` for payload embedding.
 - `BOOT_TEST`: `1` to boot the ISO in QEMU after building.
-- `ISO_NAME`, `UKI_NAME`, `EFI_IMG_NAME`: output naming.
+- `BOOT_FIRMWARE`: `uefi` or `bios` for the local QEMU boot test.
+- `ISO_NAME`: output ISO name.
+
+These variables can also be set in front of `./build_in_container.sh`, for example:
+
+`ISO_NAME=truthdb-dev.iso ./build_in_container.sh`
+
+To build locally but use the latest published `truthdb` / `installer` / `installer-kernel` release artifacts instead of local workspace binaries:
+
+`INPUT_MODE=release ./build_in_container.sh`
+
+To force a QEMU boot test from inside the container:
+
+`BOOT_TEST=1 ./build_in_container.sh`
+
+If `KERNEL_SRC` or `INSTALLER_BIN` point at files inside this workspace on the host, `build_in_container.sh` rewrites those paths for the container automatically.
+
+Mode summary:
+
+- `INPUT_MODE=dev`: builds local `truthdb` and `installer`, builds the Debian payload locally, downloads `installer-kernel` unless `KERNEL_SRC` is set
+- `INPUT_MODE=release`: downloads published `truthdb`, `installer`, and `installer-kernel` artifacts and builds the Debian payload from the published `truthdb` release assets
+
+Implementation note:
+
+- The release workflow and local `INPUT_MODE=release` path both use `build_rootfs_payload.sh` plus `build_iso.sh`
+- Local `INPUT_MODE=dev` uses the same scripts, but feeds them local workspace artifacts by default
 
 ## Releases
 
 On tag pushes (`v*`), the release workflow:
 
 - Builds a Debian (bookworm/amd64) minbase payload via `debootstrap`
+- Uses the shared `build_rootfs_payload.sh` implementation in `TRUTHDB_SOURCE=release` mode
 - Downloads the current latest released `truthdb`, `installer`, and `installer-kernel` artifacts and verifies their published checksums
 - Embeds the payload at `/payload/debian-minbase-amd64-bookworm.tar.zst` in initramfs
 - Copies required external tools (partitioning, filesystems, tar/zstd, chroot, efibootmgr, systemd-boot EFI bits) into initramfs
+- Builds a GRUB boot menu with normal, safe-graphics, debug, serial-console, and rescue entries
 - Produces `truthdb-installer-vX.Y.Z.iso` + `truthdb-installer-vX.Y.Z.iso.sha256`
 
 The workflow does not version-lock dependency artifacts. To control what gets embedded, publish the desired `truthdb`, `installer`, and `installer-kernel` releases before tagging `installer-iso`.

--- a/build_and_run.sh
+++ b/build_and_run.sh
@@ -4,21 +4,104 @@ set -euo pipefail
 export DEBIAN_FRONTEND=noninteractive
 
 # ================= CONFIG =================
-KERNEL_SRC="${KERNEL_SRC:-}"  # must be a Linux kernel image (bzImage/vmlinuz)
-INSTALLER_BIN="${INSTALLER_BIN:-/work/installer/target/x86_64-unknown-linux-musl/release/truthdb-installer}"
+INPUT_MODE="${INPUT_MODE:-dev}"  # dev|release
+KERNEL_SRC="${KERNEL_SRC:-}"     # must be a Linux kernel image (bzImage/vmlinuz)
+INSTALLER_BIN="${INSTALLER_BIN:-}"
+INSTALLER_BIN_WAS_EXPLICIT=0
+if [[ -n "${INSTALLER_BIN}" ]]; then
+  INSTALLER_BIN_WAS_EXPLICIT=1
+else
+  INSTALLER_BIN=/work/installer/target/x86_64-unknown-linux-musl/release/truthdb-installer
+fi
 
-# If KERNEL_SRC is not provided, fetch BOOTX64.EFI from Truthdb/installer-kernel releases.
+# If KERNEL_SRC is not provided, fetch the installer-kernel release asset.
+# The published asset is historically named BOOTX64.EFI, but it is the Linux
+# kernel image we want GRUB to boot.
 # - If KERNEL_TAG is set (e.g. v1.2.3), fetch that exact release.
 # - Otherwise, fetch the latest release.
 KERNEL_TAG="${KERNEL_TAG:-}"
 KERNEL_REPO="${KERNEL_REPO:-Truthdb/installer-kernel}"
+INSTALLER_REPO="${INSTALLER_REPO:-Truthdb/installer}"
+TRUTHDB_REPO="${TRUTHDB_REPO:-Truthdb/truthdb}"
 
 ISO_NAME="${ISO_NAME:-truthdb-installer.iso}"
-UKI_NAME="${UKI_NAME:-TruthDBInstaller.efi}"
-EFI_IMG_NAME="${EFI_IMG_NAME:-efi.img}"
+ROOTFS_PAYLOAD="${ROOTFS_PAYLOAD:-}"
 
-BUILD_INSTALLER="${BUILD_INSTALLER:-0}"  # 1=yes, 0=no
+case "${INPUT_MODE}" in
+  dev)
+    default_build_installer=1
+    default_build_truthdb=1
+    default_truthdb_source=local
+    ;;
+  release)
+    default_build_installer=0
+    default_build_truthdb=0
+    default_truthdb_source=release
+    ;;
+  *)
+    echo "ERROR: unsupported INPUT_MODE: ${INPUT_MODE}" >&2
+    exit 1
+    ;;
+esac
+
+BUILD_INSTALLER="${BUILD_INSTALLER:-$default_build_installer}"  # 1=yes, 0=no
+BUILD_TRUTHDB="${BUILD_TRUTHDB:-$default_build_truthdb}"      # 1=yes, 0=no
+BUILD_ROOTFS_PAYLOAD="${BUILD_ROOTFS_PAYLOAD:-1}"  # 1=yes, 0=no
+TRUTHDB_SOURCE="${TRUTHDB_SOURCE:-$default_truthdb_source}"  # auto|local|release
 BOOT_TEST="${BOOT_TEST:-1}"              # 1=yes, 0=no
+BOOT_FIRMWARE="${BOOT_FIRMWARE:-uefi}"   # uefi|bios
+
+GENERATED_ROOTFS_PAYLOAD=0
+
+cleanup_generated_payload() {
+  if [[ "${GENERATED_ROOTFS_PAYLOAD}" != "1" ]]; then
+    return 0
+  fi
+  rm -rf /tmp/truthdb-installer-rootfs /tmp/debian-minbase-amd64-bookworm.tar.zst
+}
+
+trap cleanup_generated_payload EXIT
+
+curl_args=(-fsSL -H "Accept: application/vnd.github+json")
+if [[ -n "${GITHUB_TOKEN:-}" ]]; then
+  curl_args+=(-H "Authorization: Bearer ${GITHUB_TOKEN}")
+fi
+
+download_release_installer() {
+  local release download_url checksum_url expected_sha actual_sha
+
+  echo "INSTALLER_BIN not set; downloading installer from latest release of ${INSTALLER_REPO}"
+  release="$(curl "${curl_args[@]}" "https://api.github.com/repos/${INSTALLER_REPO}/releases/latest")"
+
+  download_url="$(echo "${release}" | jq -r '.assets // [] | .[] | select(.name | contains("truthdb-installer")) | select(.name | endswith(".tar.gz")) | .browser_download_url' | head -n 1)"
+  checksum_url="$(echo "${release}" | jq -r '.assets // [] | .[] | select(.name | contains("truthdb-installer")) | select(.name | endswith(".sha256")) | .browser_download_url' | head -n 1)"
+
+  [[ -n "${download_url}" && "${download_url}" != "null" ]] || {
+    echo "ERROR: could not find installer archive asset in latest ${INSTALLER_REPO} release" >&2
+    exit 1
+  }
+  [[ -n "${checksum_url}" && "${checksum_url}" != "null" ]] || {
+    echo "ERROR: could not find installer checksum asset in latest ${INSTALLER_REPO} release" >&2
+    exit 1
+  }
+
+  mkdir -p /work/installer-iso/installer-bin
+  curl -fsSL -o /work/installer-iso/installer-bin/installer.tar.gz "${download_url}"
+  curl -fsSL -o /work/installer-iso/installer-bin/truthdb-installer.sha256 "${checksum_url}"
+  tar xzf /work/installer-iso/installer-bin/installer.tar.gz -C /work/installer-iso/installer-bin
+
+  expected_sha="$(awk 'NR==1 {print $1}' /work/installer-iso/installer-bin/truthdb-installer.sha256)"
+  actual_sha="$(sha256sum /work/installer-iso/installer-bin/truthdb-installer | awk '{print $1}')"
+  if [[ -z "${expected_sha}" || "${expected_sha}" != "${actual_sha}" ]]; then
+    echo "ERROR: installer checksum verification failed" >&2
+    echo "Expected: ${expected_sha:-<empty>}" >&2
+    echo "Actual:   ${actual_sha}" >&2
+    exit 1
+  fi
+
+  chmod +x /work/installer-iso/installer-bin/truthdb-installer
+  INSTALLER_BIN=/work/installer-iso/installer-bin/truthdb-installer
+}
 
 # ================= SANITY =================
 if [[ "$(uname -m)" != "x86_64" ]]; then
@@ -33,9 +116,18 @@ apt-get install -y \
   build-essential pkg-config \
   cpio zstd \
   busybox-static \
+  util-linux \
+  fdisk \
+  parted \
+  e2fsprogs \
+  efibootmgr \
+  debootstrap debian-archive-keyring \
   python3 \
-  systemd-ukify \
+  systemd \
   systemd-boot-efi \
+  grub-common \
+  grub-pc-bin \
+  grub-efi-amd64-bin \
   ovmf qemu-system-x86 \
   file \
   xorriso \
@@ -44,114 +136,98 @@ apt-get install -y \
   musl-tools >/dev/null
 
 # ================= RUST (optional) =================
-if [[ "$BUILD_INSTALLER" == "1" ]]; then
+if [[ "$BUILD_INSTALLER" == "1" || "$BUILD_TRUTHDB" == "1" ]]; then
   if [[ ! -f "$HOME/.cargo/env" ]]; then
     curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
   fi
   # shellcheck disable=SC1090,SC1091
   . "$HOME/.cargo/env"
   rustup target add x86_64-unknown-linux-musl >/dev/null
+fi
 
+if [[ "$BUILD_INSTALLER" == "1" ]]; then
   pushd /work/installer >/dev/null
   cargo build --release --target x86_64-unknown-linux-musl
   popd >/dev/null
+fi
+
+if [[ "$BUILD_TRUTHDB" == "1" ]]; then
+  pushd /work/truthdb >/dev/null
+  cargo build --release
+  popd >/dev/null
+fi
+
+if [[ "${INPUT_MODE}" = "release" && "${INSTALLER_BIN_WAS_EXPLICIT}" != "1" && "${BUILD_INSTALLER}" != "1" ]]; then
+  download_release_installer
 fi
 
 if [[ -z "$KERNEL_SRC" ]]; then
   mkdir -p /work/installer-iso/kernel-bin
   if [[ -n "$KERNEL_TAG" ]]; then
     echo "KERNEL_SRC not set; downloading kernel from $KERNEL_REPO tag $KERNEL_TAG"
-    release=$(curl -fsSL "https://api.github.com/repos/${KERNEL_REPO}/releases/tags/${KERNEL_TAG}")
+    release="$(curl "${curl_args[@]}" "https://api.github.com/repos/${KERNEL_REPO}/releases/tags/${KERNEL_TAG}")"
   else
     echo "KERNEL_SRC not set; downloading kernel from latest release of $KERNEL_REPO"
-    release=$(curl -fsSL "https://api.github.com/repos/${KERNEL_REPO}/releases/latest")
+    release="$(curl "${curl_args[@]}" "https://api.github.com/repos/${KERNEL_REPO}/releases/latest")"
   fi
 
-  url=$(echo "$release" | jq -r '.assets // [] | .[] | select(.name == "BOOTX64.EFI") | .browser_download_url' | head -n 1)
+  url="$(echo "$release" | jq -r '.assets // [] | .[] | select(.name == "BOOTX64.EFI") | .browser_download_url' | head -n 1)"
+  checksum_url="$(echo "$release" | jq -r '.assets // [] | .[] | select(.name == "BOOTX64.EFI.sha256") | .browser_download_url' | head -n 1)"
   [[ -n "$url" && "$url" != "null" ]] || { echo "ERROR: could not find BOOTX64.EFI asset in release"; exit 1; }
+  [[ -n "$checksum_url" && "$checksum_url" != "null" ]] || { echo "ERROR: could not find BOOTX64.EFI.sha256 asset in release"; exit 1; }
 
   curl -fsSL -o /work/installer-iso/kernel-bin/BOOTX64.EFI "$url"
+  curl -fsSL -o /work/installer-iso/kernel-bin/BOOTX64.EFI.sha256 "$checksum_url"
+  (
+    cd /work/installer-iso/kernel-bin
+    sha256sum -c BOOTX64.EFI.sha256
+  )
   KERNEL_SRC=/work/installer-iso/kernel-bin/BOOTX64.EFI
 fi
 
 [[ -f "$KERNEL_SRC" ]] || { echo "ERROR: KERNEL_SRC does not exist: $KERNEL_SRC"; exit 1; }
+if [[ ! -x "$INSTALLER_BIN" ]]; then
+  if [[ "${INPUT_MODE}" = "release" && "${INSTALLER_BIN_WAS_EXPLICIT}" != "1" ]]; then
+    download_release_installer
+  fi
+fi
 [[ -x "$INSTALLER_BIN" ]] || { echo "ERROR: installer binary not found: $INSTALLER_BIN"; exit 1; }
 
 # ================= WORKDIR =================
 cd /work/installer-iso
 
-# ================= INITRAMFS =================
-rm -rf rootfs
-mkdir -p rootfs/{bin,sbin,etc,proc,sys,dev,run,tmp}
-
-cp /bin/busybox rootfs/bin/busybox
-chmod +x rootfs/bin/busybox
-ln -sf /bin/busybox rootfs/sbin/init
-ln -sf /bin/busybox rootfs/bin/sh
-
-cp "$INSTALLER_BIN" rootfs/bin/truthdb-installer
-chmod +x rootfs/bin/truthdb-installer
-
-cat > rootfs/etc/inittab <<'EOF'
-::sysinit:/bin/busybox mount -t proc proc /proc
-::sysinit:/bin/busybox mount -t sysfs sysfs /sys
-::sysinit:/bin/busybox mount -t devtmpfs devtmpfs /dev
-#::sysinit:/bin/busybox sh -c 'echo; echo "==============================="; echo "=== TRUTHDB INITRAMFS START ==="; echo "==============================="; echo'
-#::sysinit:/bin/busybox sh -c 'echo "--- FBDEV ---"; /bin/busybox ls -l /dev/fb* 2>&1 || echo "NO /dev/fb*"'
-#::sysinit:/bin/busybox sh -c 'echo "--- DRM ---"; /bin/busybox ls -l /dev/dri/* 2>&1 || echo "NO /dev/dri/*"'
-#::sysinit:/bin/busybox sh -c 'echo "--- DMESG (graphics) ---"; /bin/busybox dmesg | /bin/busybox grep -Ei "efi|gop|efifb|simplefb|simpledrm|drm|framebuffer" || echo "NO MATCHES"'
-::respawn:/bin/busybox sh -c '/bin/truthdb-installer </dev/console >/dev/console 2>&1'
-::restart:/bin/busybox reboot -f
-EOF
-
-rm -f initramfs.cpio initramfs.cpio.zst
-( cd rootfs && find . -print0 | cpio --null -ov --format=newc ) > initramfs.cpio
-zstd -19 -T0 initramfs.cpio -o initramfs.cpio.zst
-
-# ================= CMDLINE =================
-#cat > cmdline.txt <<'EOF'
-#console=ttyS0 earlyprintk=serial loglevel=7 rdinit=/sbin/init
-#EOF
-cat > cmdline.txt <<'EOF'
-console=ttyS0,115200 earlycon=efi loglevel=7 console=tty0 rdinit=/sbin/init
-EOF
-
-# ================= UKI =================
-cp "$KERNEL_SRC" ./vmlinuz
-
-ukify build \
-  --linux ./vmlinuz \
-  --initrd ./initramfs.cpio.zst \
-  --cmdline @./cmdline.txt \
-  --output "./$UKI_NAME"
-
-file "./$UKI_NAME"
-
-# ================= EFI IMG (FAT, El Torito boot image) =================
-rm -f "./$EFI_IMG_NAME"
-dd if=/dev/zero of="./$EFI_IMG_NAME" bs=1M count=128
-mkfs.vfat -F 32 "./$EFI_IMG_NAME"
-
-mmd   -i "./$EFI_IMG_NAME" ::/EFI
-mmd   -i "./$EFI_IMG_NAME" ::/EFI/BOOT
-mcopy -i "./$EFI_IMG_NAME" "./$UKI_NAME" ::/EFI/BOOT/BOOTX64.EFI
+if [[ -z "$ROOTFS_PAYLOAD" && "$BUILD_ROOTFS_PAYLOAD" == "1" ]]; then
+  echo "ROOTFS_PAYLOAD not set; building Debian rootfs payload locally"
+  chmod +x ./build_rootfs_payload.sh
+  export TRUTHDB_BIN=/work/truthdb/target/release/truthdb
+  export TRUTHDB_SERVICE=/work/truthdb/truthdb.service
+  export TRUTHDB_REPO
+  export TRUTHDB_SOURCE
+  ROOTFS_DIR=/tmp/truthdb-installer-rootfs \
+  PAYLOAD_PATH=/tmp/debian-minbase-amd64-bookworm.tar.zst \
+    ./build_rootfs_payload.sh
+  ROOTFS_PAYLOAD=/tmp/debian-minbase-amd64-bookworm.tar.zst
+  GENERATED_ROOTFS_PAYLOAD=1
+fi
 
 # ================= ISO =================
-rm -f "$ISO_NAME"
-
-xorriso -as mkisofs \
-  -R -J \
-  -o "$ISO_NAME" \
-  -eltorito-alt-boot \
-  -e "$EFI_IMG_NAME" \
-  -no-emul-boot \
-  -isohybrid-gpt-basdat \
-  -graft-points "$EFI_IMG_NAME"="$EFI_IMG_NAME"
-
-echo "ISO ready: $ISO_NAME"
+export KERNEL_SRC INSTALLER_BIN ISO_NAME ROOTFS_PAYLOAD
+chmod +x ./build_iso.sh
+./build_iso.sh
 
 # ================= BOOT TEST (QEMU) =================
 if [[ "$BOOT_TEST" == "1" ]]; then
+  if [[ "$BOOT_FIRMWARE" == "bios" ]]; then
+    exec qemu-system-x86_64 \
+      -m 2048 \
+      -machine q35 \
+      -accel tcg \
+      -serial stdio \
+      -drive file="$ISO_NAME",media=cdrom,readonly=on \
+      -boot order=d,menu=on \
+      -net none
+  fi
+
   cp /usr/share/OVMF/OVMF_CODE_4M.fd ./OVMF_CODE.fd
   cp /usr/share/OVMF/OVMF_VARS_4M.fd ./OVMF_VARS.fd
 

--- a/build_in_container.sh
+++ b/build_in_container.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WORKSPACE_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+# The one-shot wrapper should produce an ISO from a clean macOS/Linux host
+# without requiring a prebuilt installer binary or a containerized QEMU run.
+INPUT_MODE="${INPUT_MODE:-dev}"
+case "${INPUT_MODE}" in
+  dev)
+    BUILD_INSTALLER="${BUILD_INSTALLER:-1}"
+    BUILD_TRUTHDB="${BUILD_TRUTHDB:-1}"
+    TRUTHDB_SOURCE="${TRUTHDB_SOURCE:-local}"
+    ;;
+  release)
+    BUILD_INSTALLER="${BUILD_INSTALLER:-0}"
+    BUILD_TRUTHDB="${BUILD_TRUTHDB:-0}"
+    TRUTHDB_SOURCE="${TRUTHDB_SOURCE:-release}"
+    ;;
+  *)
+    echo "ERROR: unsupported INPUT_MODE: ${INPUT_MODE}" >&2
+    exit 1
+    ;;
+esac
+BUILD_ROOTFS_PAYLOAD="${BUILD_ROOTFS_PAYLOAD:-1}"
+BOOT_TEST="${BOOT_TEST:-0}"
+
+translate_workspace_path() {
+  local value="$1"
+  if [[ -z "$value" ]]; then
+    return 0
+  fi
+  if [[ "$value" == "${WORKSPACE_ROOT}"/* ]]; then
+    printf '/work%s' "${value#"${WORKSPACE_ROOT}"}"
+    return 0
+  fi
+  printf '%s' "$value"
+}
+
+docker_args=(
+  run
+  --rm
+  -it
+  --platform=linux/amd64
+  -v "${WORKSPACE_ROOT}:/work"
+  -w /work/installer-iso
+)
+
+for name in \
+  KERNEL_SRC \
+  INSTALLER_BIN \
+  ROOTFS_PAYLOAD \
+  INPUT_MODE \
+  KERNEL_TAG \
+  KERNEL_REPO \
+  INSTALLER_REPO \
+  TRUTHDB_REPO \
+  ISO_NAME \
+  BUILD_INSTALLER \
+  BUILD_TRUTHDB \
+  BUILD_ROOTFS_PAYLOAD \
+  TRUTHDB_SOURCE \
+  BOOT_TEST \
+  BOOT_FIRMWARE
+do
+  if [[ -n "${!name:-}" ]]; then
+    value="${!name}"
+    case "$name" in
+      KERNEL_SRC|INSTALLER_BIN|ROOTFS_PAYLOAD)
+        value="$(translate_workspace_path "$value")"
+        ;;
+    esac
+    docker_args+=(-e "${name}=${value}")
+  fi
+done
+
+docker_args+=(
+  -e "INPUT_MODE=${INPUT_MODE}"
+  -e "BUILD_INSTALLER=${BUILD_INSTALLER}"
+  -e "BUILD_TRUTHDB=${BUILD_TRUTHDB}"
+  -e "BUILD_ROOTFS_PAYLOAD=${BUILD_ROOTFS_PAYLOAD}"
+  -e "TRUTHDB_SOURCE=${TRUTHDB_SOURCE}"
+  -e "BOOT_TEST=${BOOT_TEST}"
+  ubuntu:24.04
+  bash
+  -lc
+  "./build_and_run.sh"
+)
+
+exec docker "${docker_args[@]}"

--- a/build_iso.sh
+++ b/build_iso.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+KERNEL_SRC="${KERNEL_SRC:-}"
+INSTALLER_BIN="${INSTALLER_BIN:-}"
+ISO_NAME="${ISO_NAME:-truthdb-installer.iso}"
+ROOTFS_PAYLOAD="${ROOTFS_PAYLOAD:-}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+INIT_TEMPLATE="${SCRIPT_DIR}/initramfs/init"
+GRUB_CFG_TEMPLATE="${SCRIPT_DIR}/grub/grub.cfg"
+
+[[ -n "${KERNEL_SRC}" ]] || { echo "ERROR: KERNEL_SRC is required"; exit 1; }
+[[ -f "${KERNEL_SRC}" ]] || { echo "ERROR: KERNEL_SRC does not exist: ${KERNEL_SRC}"; exit 1; }
+[[ -n "${INSTALLER_BIN}" ]] || { echo "ERROR: INSTALLER_BIN is required"; exit 1; }
+[[ -x "${INSTALLER_BIN}" ]] || { echo "ERROR: INSTALLER_BIN is not executable: ${INSTALLER_BIN}"; exit 1; }
+[[ -f "${INIT_TEMPLATE}" ]] || { echo "ERROR: missing init template: ${INIT_TEMPLATE}"; exit 1; }
+[[ -f "${GRUB_CFG_TEMPLATE}" ]] || { echo "ERROR: missing GRUB config template: ${GRUB_CFG_TEMPLATE}"; exit 1; }
+
+copy_bin_with_libs() {
+  local src="$1"
+  if [[ ! -x "$src" ]]; then
+    echo "ERROR: required tool not found or not executable: $src" >&2
+    exit 1
+  fi
+
+  mkdir -p "rootfs$(dirname "$src")"
+  cp -L "$src" "rootfs$src"
+
+  ldd "$src" 2>/dev/null \
+    | awk '{ for (i = 1; i <= NF; i++) if ($i ~ /^\//) print $i }' \
+    | while read -r dep; do
+        mkdir -p "rootfs$(dirname "$dep")"
+        cp -L "$dep" "rootfs$dep"
+      done
+}
+
+copy_required_cmd() {
+  local cmd="$1"
+  local path
+  path="$(command -v "$cmd" || true)"
+  [[ -n "$path" ]] || {
+    echo "ERROR: required tool not found in PATH: $cmd" >&2
+    exit 1
+  }
+  copy_bin_with_libs "$path"
+}
+
+rm -rf rootfs iso-root
+mkdir -p rootfs/{bin,sbin,etc,proc,sys,dev,run,tmp,dev/pts}
+
+cp /bin/busybox rootfs/bin/busybox
+chmod +x rootfs/bin/busybox
+ln -sf /bin/busybox rootfs/bin/sh
+
+cp "${INIT_TEMPLATE}" rootfs/init
+chmod +x rootfs/init
+
+cp "${INSTALLER_BIN}" rootfs/bin/truthdb-installer
+chmod +x rootfs/bin/truthdb-installer
+
+if [[ -n "${ROOTFS_PAYLOAD}" ]]; then
+  [[ -f "${ROOTFS_PAYLOAD}" ]] || { echo "ERROR: ROOTFS_PAYLOAD does not exist: ${ROOTFS_PAYLOAD}"; exit 1; }
+  mkdir -p rootfs/payload
+  cp "${ROOTFS_PAYLOAD}" rootfs/payload/debian-minbase-amd64-bookworm.tar.zst
+fi
+
+# Required external tools for destructive install steps.
+copy_required_cmd wipefs
+copy_required_cmd sfdisk
+copy_required_cmd partprobe
+copy_required_cmd blkid
+copy_required_cmd mkfs.vfat
+copy_required_cmd mkfs.ext4
+copy_required_cmd mount
+copy_required_cmd umount
+copy_required_cmd tar
+copy_required_cmd zstd
+
+chroot_path="$(command -v chroot || true)"
+[[ -n "${chroot_path}" ]] || { echo "ERROR: chroot not found in PATH"; exit 1; }
+copy_bin_with_libs "${chroot_path}"
+
+efibootmgr_path="$(command -v efibootmgr || true)"
+[[ -n "${efibootmgr_path}" ]] || { echo "ERROR: efibootmgr not found in PATH"; exit 1; }
+copy_bin_with_libs "${efibootmgr_path}"
+
+bootctl_path="$(command -v bootctl || true)"
+if [[ -n "${bootctl_path}" ]]; then
+  copy_bin_with_libs "${bootctl_path}"
+fi
+
+if [[ -d /usr/lib/systemd/boot/efi ]]; then
+  mkdir -p rootfs/usr/lib/systemd/boot
+  cp -a /usr/lib/systemd/boot/efi rootfs/usr/lib/systemd/boot/
+else
+  echo "ERROR: /usr/lib/systemd/boot/efi not found (need systemd-boot EFI binaries)" >&2
+  exit 1
+fi
+
+rm -f initrd.img
+( cd rootfs && find . -print0 | cpio --null -ov --format=newc ) \
+  | zstd -19 -T0 -o initrd.img
+
+mkdir -p iso-root/boot/grub iso-root/boot/truthdb
+cp "${GRUB_CFG_TEMPLATE}" iso-root/boot/grub/grub.cfg
+cp "${KERNEL_SRC}" iso-root/boot/truthdb/vmlinuz
+cp initrd.img iso-root/boot/truthdb/initrd.img
+
+rm -f "${ISO_NAME}"
+grub-mkrescue -o "${ISO_NAME}" iso-root
+
+echo "ISO ready: ${ISO_NAME}"
+ls -lh "${ISO_NAME}"

--- a/build_rootfs_payload.sh
+++ b/build_rootfs_payload.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export DEBIAN_FRONTEND="${DEBIAN_FRONTEND:-noninteractive}"
+
+TRUTHDB_REPO="${TRUTHDB_REPO:-Truthdb/truthdb}"
+TRUTHDB_BIN="${TRUTHDB_BIN:-}"
+TRUTHDB_SERVICE="${TRUTHDB_SERVICE:-}"
+TRUTHDB_SOURCE="${TRUTHDB_SOURCE:-auto}"  # auto|local|release
+PAYLOAD_NAME="${PAYLOAD_NAME:-debian-minbase-amd64-bookworm.tar.zst}"
+ROOTFS_DIR="${ROOTFS_DIR:-${PWD}/debian-rootfs}"
+PAYLOAD_PATH="${PAYLOAD_PATH:-${PWD}/${PAYLOAD_NAME}}"
+DEBIAN_MIRROR="${DEBIAN_MIRROR:-http://deb.debian.org/debian}"
+KEEP_ROOTFS_DIR="${KEEP_ROOTFS_DIR:-0}"
+
+run_as_root() {
+  if [[ "$(id -u)" -eq 0 ]]; then
+    "$@"
+    return
+  fi
+  sudo "$@"
+}
+
+curl_args=(-fsSL -H "Accept: application/vnd.github+json")
+if [[ -n "${GITHUB_TOKEN:-}" ]]; then
+  curl_args+=(-H "Authorization: Bearer ${GITHUB_TOKEN}")
+fi
+
+use_local_truthdb=0
+have_local_truthdb=0
+if [[ -n "${TRUTHDB_BIN}" && -n "${TRUTHDB_SERVICE}" && -f "${TRUTHDB_BIN}" && -f "${TRUTHDB_SERVICE}" ]]; then
+  if file "${TRUTHDB_BIN}" | grep -q 'ELF 64-bit'; then
+    have_local_truthdb=1
+  else
+    echo "WARN: TRUTHDB_BIN is not an ELF Linux binary" >&2
+  fi
+fi
+
+case "${TRUTHDB_SOURCE}" in
+  auto)
+    use_local_truthdb="${have_local_truthdb}"
+    ;;
+  local)
+    if [[ "${have_local_truthdb}" != "1" ]]; then
+      echo "ERROR: TRUTHDB_SOURCE=local requires a Linux ELF truthdb binary and truthdb.service" >&2
+      exit 1
+    fi
+    use_local_truthdb=1
+    ;;
+  release)
+    use_local_truthdb=0
+    ;;
+  *)
+    echo "ERROR: unsupported TRUTHDB_SOURCE: ${TRUTHDB_SOURCE}" >&2
+    exit 1
+    ;;
+esac
+
+echo "==> Building Debian rootfs payload"
+run_as_root rm -rf "${ROOTFS_DIR}" "${PAYLOAD_PATH}" truthdb-dist
+
+run_as_root debootstrap \
+  --arch=amd64 \
+  --variant=minbase \
+  --include=systemd-sysv,systemd-resolved,linux-image-amd64,initramfs-tools,ca-certificates,sudo,passwd,iproute2,dbus \
+  bookworm \
+  "${ROOTFS_DIR}" \
+  "${DEBIAN_MIRROR}"
+
+mkdir -p truthdb-dist
+
+if [[ "${use_local_truthdb}" = "1" ]]; then
+  echo "==> Using local truthdb build"
+  cp "${TRUTHDB_BIN}" truthdb-dist/truthdb
+  cp "${TRUTHDB_SERVICE}" truthdb-dist/truthdb.service
+else
+  echo "==> Resolving latest truthdb release"
+  release="$(curl "${curl_args[@]}" "https://api.github.com/repos/${TRUTHDB_REPO}/releases/latest")"
+
+  download_url="$(echo "${release}" | jq -r '.assets // [] | .[] | select(.name | endswith("-x86_64-linux-gnu.tar.gz")) | .browser_download_url' | head -n 1)"
+  checksum_url="$(echo "${release}" | jq -r '.assets // [] | .[] | select(.name | endswith("-x86_64-linux-gnu.sha256")) | .browser_download_url' | head -n 1)"
+
+  [[ -n "${download_url}" && "${download_url}" != "null" ]] || {
+    echo "ERROR: No truthdb binary archive found in latest release" >&2
+    exit 1
+  }
+  [[ -n "${checksum_url}" && "${checksum_url}" != "null" ]] || {
+    echo "ERROR: No truthdb checksum found in latest release" >&2
+    exit 1
+  }
+
+  curl -fsSL -o truthdb-dist/truthdb.tar.gz "${download_url}"
+  curl -fsSL -o truthdb-dist/truthdb.sha256 "${checksum_url}"
+  tar xzf truthdb-dist/truthdb.tar.gz -C truthdb-dist
+
+  expected_truthdb_sha="$(awk 'NR==1 {print $1}' truthdb-dist/truthdb.sha256)"
+  actual_truthdb_sha="$(sha256sum truthdb-dist/truthdb | awk '{print $1}')"
+  if [[ -z "${expected_truthdb_sha}" || "${expected_truthdb_sha}" != "${actual_truthdb_sha}" ]]; then
+    echo "ERROR: truthdb checksum verification failed" >&2
+    echo "Expected: ${expected_truthdb_sha:-<empty>}" >&2
+    echo "Actual:   ${actual_truthdb_sha}" >&2
+    exit 1
+  fi
+fi
+
+test -x truthdb-dist/truthdb
+test -f truthdb-dist/truthdb.service
+
+run_as_root install -d \
+  "${ROOTFS_DIR}/usr/local/bin" \
+  "${ROOTFS_DIR}/lib/systemd/system" \
+  "${ROOTFS_DIR}/etc/systemd/system/multi-user.target.wants"
+run_as_root install -m 0755 truthdb-dist/truthdb "${ROOTFS_DIR}/usr/local/bin/truthdb"
+run_as_root install -m 0644 truthdb-dist/truthdb.service "${ROOTFS_DIR}/lib/systemd/system/truthdb.service"
+run_as_root ln -sf /lib/systemd/system/truthdb.service \
+  "${ROOTFS_DIR}/etc/systemd/system/multi-user.target.wants/truthdb.service"
+
+test -x "${ROOTFS_DIR}/usr/local/bin/truthdb"
+test -f "${ROOTFS_DIR}/lib/systemd/system/truthdb.service"
+test -L "${ROOTFS_DIR}/etc/systemd/system/multi-user.target.wants/truthdb.service"
+
+run_as_root rm -rf "${ROOTFS_DIR}/var/lib/apt/lists/"* || true
+run_as_root rm -rf "${ROOTFS_DIR}/var/cache/apt/archives/"*.deb || true
+run_as_root rm -rf "${ROOTFS_DIR}/usr/share/doc" || true
+run_as_root rm -rf "${ROOTFS_DIR}/usr/share/man" || true
+run_as_root rm -rf "${ROOTFS_DIR}/usr/share/info" || true
+run_as_root rm -rf "${ROOTFS_DIR}/usr/share/locale" || true
+
+run_as_root tar --numeric-owner -C "${ROOTFS_DIR}" -cpf - . \
+  | zstd -19 -T0 -o "${PAYLOAD_PATH}"
+
+if [[ "${KEEP_ROOTFS_DIR}" != "1" ]]; then
+  run_as_root rm -rf "${ROOTFS_DIR}"
+fi
+
+rm -rf truthdb-dist
+
+echo "Payload ready: ${PAYLOAD_PATH}"
+ls -lh "${PAYLOAD_PATH}"

--- a/grub/grub.cfg
+++ b/grub/grub.cfg
@@ -1,0 +1,32 @@
+set default=0
+set timeout=5
+
+menuentry "Install TruthDB" {
+    linux /boot/truthdb/vmlinuz console=tty0 quiet loglevel=3 vt.global_cursor_default=0 rdinit=/init
+    initrd /boot/truthdb/initrd.img
+}
+
+menuentry "Install TruthDB (dedicated VT)" {
+    linux /boot/truthdb/vmlinuz console=tty0 quiet loglevel=3 vt.global_cursor_default=0 rdinit=/init truthdb.ui_vt1=1
+    initrd /boot/truthdb/initrd.img
+}
+
+menuentry "Install TruthDB (safe graphics)" {
+    linux /boot/truthdb/vmlinuz console=tty0 quiet loglevel=3 vt.global_cursor_default=0 nomodeset rdinit=/init
+    initrd /boot/truthdb/initrd.img
+}
+
+menuentry "Install TruthDB (verbose debug)" {
+    linux /boot/truthdb/vmlinuz console=tty0 console=ttyS0,115200 earlycon=efi loglevel=7 rdinit=/init truthdb.debug=1
+    initrd /boot/truthdb/initrd.img
+}
+
+menuentry "Install TruthDB (serial console)" {
+    linux /boot/truthdb/vmlinuz console=ttyS0,115200 loglevel=4 rdinit=/init truthdb.debug=1 truthdb.serial_ui=1
+    initrd /boot/truthdb/initrd.img
+}
+
+menuentry "Rescue shell" {
+    linux /boot/truthdb/vmlinuz console=tty0 loglevel=4 rdinit=/init truthdb.rescue=1
+    initrd /boot/truthdb/initrd.img
+}

--- a/initramfs/init
+++ b/initramfs/init
@@ -1,0 +1,59 @@
+#!/bin/busybox sh
+set -eu
+
+export PATH=/bin:/sbin:/usr/bin:/usr/sbin
+
+has_flag() {
+  for arg in $(cat /proc/cmdline); do
+    if [ "$arg" = "$1" ]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+mount -t proc proc /proc
+mount -t sysfs sysfs /sys
+mount -t devtmpfs devtmpfs /dev
+mkdir -p /dev/pts /run /tmp
+mount -t devpts devpts /dev/pts 2>/dev/null || true
+mount -t tmpfs tmpfs /run 2>/dev/null || true
+
+echo /bin/busybox mdev > /proc/sys/kernel/hotplug 2>/dev/null || true
+/bin/busybox mdev -s 2>/dev/null || true
+
+if ! has_flag truthdb.debug=1; then
+  echo 1 > /proc/sys/kernel/printk 2>/dev/null || true
+  /bin/busybox dmesg -n 1 2>/dev/null || true
+fi
+
+ui_tty="/dev/console"
+if has_flag truthdb.serial_ui=1; then
+  ui_tty="/dev/ttyS0"
+elif has_flag truthdb.ui_vt1=1; then
+  ui_tty="/dev/tty1"
+fi
+if [ ! -c "$ui_tty" ]; then
+  ui_tty="/dev/console"
+fi
+
+if [ "$ui_tty" = "/dev/tty1" ]; then
+  /bin/busybox chvt 1 >/dev/null 2>&1 || true
+fi
+
+exec <"$ui_tty" >"$ui_tty" 2>&1
+/bin/busybox clear >/dev/null 2>&1 || true
+
+if has_flag truthdb.rescue=1; then
+  echo "TruthDB rescue shell"
+  exec /bin/busybox setsid /bin/busybox cttyhack /bin/busybox sh
+fi
+
+echo "Starting TruthDB installer..."
+if /bin/busybox setsid /bin/busybox cttyhack /bin/truthdb-installer; then
+  exec /bin/busybox reboot -f
+fi
+
+echo
+echo "[ERR] Installer exited unexpectedly. Opening rescue shell."
+exec /bin/busybox setsid /bin/busybox cttyhack /bin/busybox sh

--- a/initramfs/init
+++ b/initramfs/init
@@ -1,10 +1,15 @@
 #!/bin/busybox sh
+# shellcheck shell=dash
 set -eu
 
 export PATH=/bin:/sbin:/usr/bin:/usr/sbin
 
 has_flag() {
-  for arg in $(cat /proc/cmdline); do
+  cmdline=
+  if [ -r /proc/cmdline ]; then
+    cmdline=$(cat /proc/cmdline)
+  fi
+  for arg in $cmdline; do
     if [ "$arg" = "$1" ]; then
       return 0
     fi
@@ -41,7 +46,9 @@ if [ "$ui_tty" = "/dev/tty1" ]; then
   /bin/busybox chvt 1 >/dev/null 2>&1 || true
 fi
 
-exec <"$ui_tty" >"$ui_tty" 2>&1
+exec 0<"$ui_tty"
+exec 1>"$ui_tty"
+exec 2>&1
 /bin/busybox clear >/dev/null 2>&1 || true
 
 if has_flag truthdb.rescue=1; then


### PR DESCRIPTION
- Updated README.md to reflect changes in the boot process and build scripts.
- Modified .gitignore to include new files generated during the build process.
- Replaced UKI-based booting with GRUB in build_and_run.sh and build_iso.sh.
- Introduced build_in_container.sh for simplified local development and testing.
- Created build_rootfs_payload.sh to manage Debian rootfs payload creation.
- Added initramfs/init and grub/grub.cfg for improved boot configuration and installer execution.
- Enhanced error handling and validation in build scripts.
- Updated environment variables for better control over build modes and dependencies.

## Summary

Describe what this PR changes and why.

## Checklist

- [ ] I kept the change focused and scoped
- [ ] I ran relevant tests/lints locally (or explained why not)
- [ ] I updated documentation where needed
- [ ] I considered backwards compatibility and migration impact

## Testing

Describe what you tested and how.
